### PR TITLE
Updated prototype - implemented SharedPreferences in app.

### DIFF
--- a/app/src/main/java/pilot/cs262/calvin/edu/knightrank/AccountCreation.java
+++ b/app/src/main/java/pilot/cs262/calvin/edu/knightrank/AccountCreation.java
@@ -1,6 +1,7 @@
 package pilot.cs262.calvin.edu.knightrank;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
@@ -16,17 +17,27 @@ public class AccountCreation extends AppCompatActivity {
     private static final String LOG_TAG =
             MainActivity.class.getSimpleName();
 
+    private static final String USER_NAME = "";
+    private static final String USER_PASSWORD = "";
+    private static final String CONFIRM_PASSWORD = "";
+
     private EditText username;
     private EditText password;
     private EditText confirmPassword;
+
+    // Share preferences file.
+    private SharedPreferences mPreferences;
+    private String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_account_creation);
-        username = (EditText) findViewById(R.id.editText_username_create);
-        password = (EditText) findViewById(R.id.editText_password_create);
-        confirmPassword = (EditText) findViewById(R.id.editText_confirm_Password_create);
+
+        // Find UI components.
+        username = findViewById(R.id.editText_username_create);
+        password = findViewById(R.id.editText_password_create);
+        confirmPassword = findViewById(R.id.editText_confirm_Password_create);
 
         // my_child_toolbar is defined in the layout file
         Toolbar myToolbar = (Toolbar) findViewById(R.id.my_toolbar);
@@ -39,6 +50,14 @@ public class AccountCreation extends AppCompatActivity {
         if (ab != null) {
             ab.setDisplayHomeAsUpEnabled(true);
         }
+
+        // Set shared preferences component.
+        mPreferences = getSharedPreferences(sharedPrefFile, MODE_PRIVATE);
+
+        // Restores user name and user password from saved preferences file.
+        username.setText(mPreferences.getString(USER_NAME, ""));
+        password.setText(mPreferences.getString(USER_PASSWORD, ""));
+        confirmPassword.setText(mPreferences.getString(CONFIRM_PASSWORD, ""));
     }
 
     /**
@@ -55,6 +74,13 @@ public class AccountCreation extends AppCompatActivity {
         Log.d(LOG_TAG, "Button clicked!");
     }
 
+    /**
+     * Method performs checks and conditions on user account creation.
+     * - Valid user name (can't be an empty string)
+     * - Password match confirmation
+     *
+     * @param view view component
+     */
     public void createAccount(View view) {
         String user_name = username.getText().toString();
         String user_password = password.getText().toString();
@@ -74,7 +100,34 @@ public class AccountCreation extends AppCompatActivity {
         } else {
             Toast.makeText(getApplicationContext(), "Username must not be blank.", Toast.LENGTH_LONG).show();
         }
+    }
 
+    /**
+     * Method currently called to store values to shared preferences file.
+     */
+    @Override
+    protected void onPause() {
+        super.onPause();
 
+        SharedPreferences.Editor preferencesEditor = mPreferences.edit();
+
+        preferencesEditor.putString(USER_NAME, username.getText().toString());
+        preferencesEditor.putString(USER_PASSWORD, password.getText().toString());
+        preferencesEditor.putString(CONFIRM_PASSWORD, confirmPassword.getText().toString());
+
+        preferencesEditor.apply();
+    }
+
+    /**
+     * Method resets the shared preferences file if we desire to.
+     *
+     * @param view view component
+     */
+    public void resetSharedPreferences(View view){
+
+        // Clear preferences
+        SharedPreferences.Editor preferencesEditor = mPreferences.edit();
+        preferencesEditor.clear();
+        preferencesEditor.apply();
     }
 }

--- a/app/src/main/java/pilot/cs262/calvin/edu/knightrank/ActivityRankings.java
+++ b/app/src/main/java/pilot/cs262/calvin/edu/knightrank/ActivityRankings.java
@@ -1,6 +1,7 @@
 package pilot.cs262.calvin.edu.knightrank;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -26,7 +27,14 @@ public class ActivityRankings extends AppCompatActivity
     private static final String LOG_TAG =
             ActivityRankings.class.getSimpleName();
 
+    // For use with shared preferences.
+    private static final String PLACEHOLDER1 = "";
+
     private DrawerLayout mDrawerLayout;
+
+    // Share preferences file.
+    private SharedPreferences mPreferences;
+    private String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
@@ -60,7 +68,15 @@ public class ActivityRankings extends AppCompatActivity
         // Method call to manipulate drawer states.
         navDrawerStates();
 
+        // Set shared preferences component.
+        mPreferences = getSharedPreferences(sharedPrefFile, MODE_PRIVATE);
+
+        // Placeholder code as example of how to restore values to UI components from shared preferences.
+        //username_main.setText(mPreferences.getString(USER_NAME, ""));
+        //password_main.setText(mPreferences.getString(USER_PASSWORD, ""));
+
         Log.e(LOG_TAG, "Reaches end of onCreate?");
+
     }
 
     /**
@@ -233,5 +249,19 @@ public class ActivityRankings extends AppCompatActivity
     @Override
     public void onFragmentInteraction(Uri uri) {
 
+    }
+
+    /**
+     * Method currently called to store values to shared preferences file.
+     */
+    @Override
+    protected void onPause() {
+        super.onPause();
+
+        SharedPreferences.Editor preferencesEditor = mPreferences.edit();
+
+        preferencesEditor.putString(PLACEHOLDER1, "Placeholder text");
+
+        preferencesEditor.apply();
     }
 }

--- a/app/src/main/java/pilot/cs262/calvin/edu/knightrank/ActivitySelection.java
+++ b/app/src/main/java/pilot/cs262/calvin/edu/knightrank/ActivitySelection.java
@@ -1,6 +1,7 @@
 package pilot.cs262.calvin.edu.knightrank;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
@@ -13,6 +14,13 @@ public class ActivitySelection extends AppCompatActivity {
     //Class variables.
     private static final String LOG_TAG =
             ActivitySelection.class.getSimpleName();
+
+    // For use with shared preferences.
+    private static final String PLACEHOLDER1 = "";
+
+    // Share preferences file.
+    private SharedPreferences mPreferences;
+    private String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -30,6 +38,13 @@ public class ActivitySelection extends AppCompatActivity {
         if (ab != null) {
             ab.setDisplayHomeAsUpEnabled(true);
         }
+
+        // Set shared preferences component.
+        mPreferences = getSharedPreferences(sharedPrefFile, MODE_PRIVATE);
+
+        // Placeholder code as example of how to restore values to UI components from shared preferences.
+        //username_main.setText(mPreferences.getString(USER_NAME, ""));
+        //password_main.setText(mPreferences.getString(USER_PASSWORD, ""));
     }
 
     /**
@@ -44,5 +59,19 @@ public class ActivitySelection extends AppCompatActivity {
         startActivity(intent);
 
         Log.d(LOG_TAG, "Button clicked!");
+    }
+
+    /**
+     * Method currently called to store values to shared preferences file.
+     */
+    @Override
+    public void onPause() {
+        super.onPause();
+
+        SharedPreferences.Editor preferencesEditor = mPreferences.edit();
+
+        preferencesEditor.putString(PLACEHOLDER1, "Placeholder text");
+
+        preferencesEditor.apply();
     }
 }

--- a/app/src/main/java/pilot/cs262/calvin/edu/knightrank/ChallengeResults.java
+++ b/app/src/main/java/pilot/cs262/calvin/edu/knightrank/ChallengeResults.java
@@ -1,5 +1,7 @@
 package pilot.cs262.calvin.edu.knightrank;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.os.Bundle;
@@ -7,11 +9,31 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.util.Objects;
+
 public class ChallengeResults extends Fragment {
+
+    // Class variables.
+
+    // For use with shared preferences.
+    private static final String PLACEHOLDER1 = "";
+
+    // Share preferences file.
+    private SharedPreferences mPreferences;
+    private String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+
         super.onCreate(savedInstanceState);
+
+        // Set shared preferences component.
+        // Note: modified from the one in activities as this is a fragment.
+        mPreferences = Objects.requireNonNull(this.getActivity()).getSharedPreferences(sharedPrefFile, Context.MODE_PRIVATE);
+
+        // Placeholder code as example of how to restore values to UI components from shared preferences.
+        //username_main.setText(mPreferences.getString(USER_NAME, ""));
+        //password_main.setText(mPreferences.getString(USER_PASSWORD, ""));
     }
 
     @Override
@@ -20,5 +42,19 @@ public class ChallengeResults extends Fragment {
 
         // Inflate the layout for this fragment
         return inflater.inflate(R.layout.fragment_challenge_results, container, false);
+    }
+
+    /**
+     * Method currently called to store values to shared preferences file.
+     */
+    @Override
+    public void onPause() {
+        super.onPause();
+
+        SharedPreferences.Editor preferencesEditor = mPreferences.edit();
+
+        preferencesEditor.putString(PLACEHOLDER1, "Placeholder text");
+
+        preferencesEditor.apply();
     }
 }

--- a/app/src/main/java/pilot/cs262/calvin/edu/knightrank/MainActivity.java
+++ b/app/src/main/java/pilot/cs262/calvin/edu/knightrank/MainActivity.java
@@ -1,6 +1,8 @@
 package pilot.cs262.calvin.edu.knightrank;
 
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -15,8 +17,16 @@ public class MainActivity extends AppCompatActivity {
     //Class variables.
     private static final String LOG_TAG =
             MainActivity.class.getSimpleName();
+
+    private static final String USER_NAME = "";
+    private static final String USER_PASSWORD = "";
+
     private EditText username_main;
     private EditText password_main;
+
+    // Share preferences file.
+    private SharedPreferences mPreferences;
+    private String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -24,16 +34,23 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
         // my_child_toolbar is defined in the layout file
-        Toolbar myToolbar = (Toolbar) findViewById(R.id.my_toolbar);
+        Toolbar myToolbar = findViewById(R.id.my_toolbar);
         setSupportActionBar(myToolbar);
 
-        username_main = (EditText) findViewById(R.id.editText_username_main);
-        password_main = (EditText) findViewById(R.id.editText_password_main);
+        // User login components.
+        username_main = findViewById(R.id.editText_username_main);
+        password_main = findViewById(R.id.editText_password_main);
 
+        // Set shared preferences component.
+        mPreferences = getSharedPreferences(sharedPrefFile, MODE_PRIVATE);
+
+        // Restores user name and user password from saved preferences file.
+        username_main.setText(mPreferences.getString(USER_NAME, ""));
+        password_main.setText(mPreferences.getString(USER_PASSWORD, ""));
     }
 
     /**
-     * Method for button click that launches the activity.
+     * Method for button click corresponding to user login.
      *
      * @param view as stated
      */
@@ -41,6 +58,7 @@ public class MainActivity extends AppCompatActivity {
         String entered_username = username_main.getText().toString();
         String entered_password = password_main.getText().toString();
 
+        // User login checks and conditions.
         if(!entered_username.equals("")) {
             if(!entered_password.equals("")) {
                 Intent intent = new Intent(this, ActivityRankings.class);
@@ -71,5 +89,33 @@ public class MainActivity extends AppCompatActivity {
         startActivity(intent);
 
         Log.d(LOG_TAG, "Button clicked!");
+    }
+
+    /**
+     * Method currently called to store values to shared preferences file.
+     */
+    @Override
+    protected void onPause() {
+        super.onPause();
+
+        SharedPreferences.Editor preferencesEditor = mPreferences.edit();
+
+        preferencesEditor.putString(USER_NAME, username_main.getText().toString());
+        preferencesEditor.putString(USER_PASSWORD, username_main.getText().toString());
+
+        preferencesEditor.apply();
+    }
+
+    /**
+     * Method resets the shared preferences file if we desire to.
+     *
+     * @param view view component
+     */
+    public void resetSharedPreferences(View view){
+
+        // Clear preferences
+        SharedPreferences.Editor preferencesEditor = mPreferences.edit();
+        preferencesEditor.clear();
+        preferencesEditor.apply();
     }
 }

--- a/app/src/main/java/pilot/cs262/calvin/edu/knightrank/MyRankings.java
+++ b/app/src/main/java/pilot/cs262/calvin/edu/knightrank/MyRankings.java
@@ -1,5 +1,7 @@
 package pilot.cs262.calvin.edu.knightrank;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.os.Bundle;
@@ -7,11 +9,31 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.util.Objects;
+
 public class MyRankings extends Fragment {
+
+    // Class variables.
+
+    // For use with shared preferences.
+    private static final String PLACEHOLDER1 = "";
+
+    // Share preferences file.
+    private SharedPreferences mPreferences;
+    private String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+
         super.onCreate(savedInstanceState);
+
+        // Set shared preferences component.
+        // Note: modified from the one in activities as this is a fragment.
+        mPreferences = Objects.requireNonNull(this.getActivity()).getSharedPreferences(sharedPrefFile, Context.MODE_PRIVATE);
+
+        // Placeholder code as example of how to restore values to UI components from shared preferences.
+        //username_main.setText(mPreferences.getString(USER_NAME, ""));
+        //password_main.setText(mPreferences.getString(USER_PASSWORD, ""));
     }
 
     @Override
@@ -20,5 +42,19 @@ public class MyRankings extends Fragment {
 
         // Inflate the layout for this fragment
         return inflater.inflate(R.layout.fragment_my_rankings, container, false);
+    }
+
+    /**
+     * Method currently called to store values to shared preferences file.
+     */
+    @Override
+    public void onPause() {
+        super.onPause();
+
+        SharedPreferences.Editor preferencesEditor = mPreferences.edit();
+
+        preferencesEditor.putString(PLACEHOLDER1, "Placeholder text");
+
+        preferencesEditor.apply();
     }
 }

--- a/app/src/main/java/pilot/cs262/calvin/edu/knightrank/NewChallenges.java
+++ b/app/src/main/java/pilot/cs262/calvin/edu/knightrank/NewChallenges.java
@@ -1,6 +1,7 @@
 package pilot.cs262.calvin.edu.knightrank;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -8,6 +9,8 @@ import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+
+import java.util.Objects;
 
 
 /**
@@ -23,6 +26,13 @@ public class NewChallenges extends Fragment {
     // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
     private static final String ARG_PARAM1 = "param1";
     private static final String ARG_PARAM2 = "param2";
+
+    // For use with shared preferences.
+    private static final String PLACEHOLDER1 = "";
+
+    // Share preferences file.
+    private SharedPreferences mPreferences;
+    private String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
 
     // TODO: Rename and change types of parameters
     private String mParam1;
@@ -59,6 +69,14 @@ public class NewChallenges extends Fragment {
             mParam1 = getArguments().getString(ARG_PARAM1);
             mParam2 = getArguments().getString(ARG_PARAM2);
         }
+
+        // Set shared preferences component.
+        // Note: modified from the one in activities as this is a fragment.
+        mPreferences = Objects.requireNonNull(this.getActivity()).getSharedPreferences(sharedPrefFile, Context.MODE_PRIVATE);
+
+        // Placeholder code as example of how to restore values to UI components from shared preferences.
+        //username_main.setText(mPreferences.getString(USER_NAME, ""));
+        //password_main.setText(mPreferences.getString(USER_PASSWORD, ""));
     }
 
     @Override
@@ -105,5 +123,19 @@ public class NewChallenges extends Fragment {
     public interface OnFragmentInteractionListener {
         // TODO: Update argument type and name
         void onFragmentInteraction(Uri uri);
+    }
+
+    /**
+     * Method currently called to store values to shared preferences file.
+     */
+    @Override
+    public void onPause() {
+        super.onPause();
+
+        SharedPreferences.Editor preferencesEditor = mPreferences.edit();
+
+        preferencesEditor.putString(PLACEHOLDER1, "Placeholder text");
+
+        preferencesEditor.apply();
     }
 }

--- a/app/src/main/java/pilot/cs262/calvin/edu/knightrank/RecentChallenges.java
+++ b/app/src/main/java/pilot/cs262/calvin/edu/knightrank/RecentChallenges.java
@@ -1,6 +1,7 @@
 package pilot.cs262.calvin.edu.knightrank;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -8,6 +9,8 @@ import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+
+import java.util.Objects;
 
 
 /**
@@ -23,6 +26,13 @@ public class RecentChallenges extends Fragment {
     // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
     private static final String ARG_PARAM1 = "param1";
     private static final String ARG_PARAM2 = "param2";
+
+    // For use with shared preferences.
+    private static final String PLACEHOLDER1 = "";
+
+    // Share preferences file.
+    private SharedPreferences mPreferences;
+    private String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
 
     // TODO: Rename and change types of parameters
     private String mParam1;
@@ -59,6 +69,14 @@ public class RecentChallenges extends Fragment {
             mParam1 = getArguments().getString(ARG_PARAM1);
             mParam2 = getArguments().getString(ARG_PARAM2);
         }
+
+        // Set shared preferences component.
+        // Note: modified from the one in activities as this is a fragment.
+        mPreferences = Objects.requireNonNull(this.getActivity()).getSharedPreferences(sharedPrefFile, Context.MODE_PRIVATE);
+
+        // Placeholder code as example of how to restore values to UI components from shared preferences.
+        //username_main.setText(mPreferences.getString(USER_NAME, ""));
+        //password_main.setText(mPreferences.getString(USER_PASSWORD, ""));
     }
 
     @Override
@@ -105,5 +123,19 @@ public class RecentChallenges extends Fragment {
     public interface OnFragmentInteractionListener {
         // TODO: Update argument type and name
         void onFragmentInteraction(Uri uri);
+    }
+
+    /**
+     * Method currently called to store values to shared preferences file.
+     */
+    @Override
+    public void onPause() {
+        super.onPause();
+
+        SharedPreferences.Editor preferencesEditor = mPreferences.edit();
+
+        preferencesEditor.putString(PLACEHOLDER1, "Placeholder text");
+
+        preferencesEditor.apply();
     }
 }


### PR DESCRIPTION
Updated prototype - implemented SharedPreferences in app.

-MainActivity.java and AccountCreation.java retain previously entered values (if any) upon return to their respective screens.

-Added SharedPreferences access, storage, and retrieval of key-value pairs across all activities and fragments in respective .java files.

-Code in most .java files are placeholder example code for when we implement necessary storage in the future.

Resources Used:

https://google-developer-training.github.io/android-developer-fundamentals-course-practicals/en/Unit%204/91_p_shared_preferences.html
https://stackoverflow.com/questions/11741270/android-sharedpreferences-in-fragment

Notes:

-OnPause() method added to all .java files as we wish to save to SharedPreferences when user isn't actively interacting with the current screen.

-resetSharedPreferences() method in MainActivity.java in case we ever wish to clear the SharedPreferences file.

-Code in activities slightly modified for fragments as their implementation details differ somewhat.

TODO: add placeholder settings to app for future implementation. (future feature branch)